### PR TITLE
Fix the error in invoking preprocess_text()

### DIFF
--- a/classifier_utils.py
+++ b/classifier_utils.py
@@ -121,7 +121,7 @@ class DataProcessor(object):
 
   def process_text(self, text):
     if self.use_spm:
-      return tokenization.preprocess_text(text, self.do_lower_case)
+      return tokenization.preprocess_text(text, lower=self.do_lower_case)
     else:
       return tokenization.convert_to_unicode(text)
 


### PR DESCRIPTION
Without specifing the lower keyword, this parameter will be incorrectly passed to the 'remove_space' parameter rather than intended 'lower' parameter of the preprocess_text() function