### PR TITLE
ensure str for the case of bytes type.

### DIFF
--- a/create_pretraining_data.py
+++ b/create_pretraining_data.py
@@ -402,7 +402,7 @@ def _is_start_piece_sp(piece):
   if (six.ensure_str(piece).startswith("▁") or
       six.ensure_str(piece).startswith("<") or piece in special_pieces or
       not all([i.lower() in english_chars.union(special_pieces)
-               for i in piece])):
+               for i in six.ensure_str(piece)])):
     return True
   else:
     return False


### PR DESCRIPTION
Hi,

I noticed that `create_pretraining_data.py` aborts by the error:

```
  File "albert/create_pretraining_data.py", line 405, in <listcomp>
    for i in piece])):
AttributeError: 'int' object has no attribute 'lower'
```
The reason why the error occurs is that the variable `piece` may be a `bytes` type in Python 3.

I'm using sentencepiece tokenizer, and, the minimal case of the input text is following (the text comes from [wikipedia](https://ja.wikipedia.org/wiki/%E3%82%AB%E3%83%A0%E3%83%87%E3%83%B3_(%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B8%E3%83%A3%E3%83%BC%E3%82%B8%E3%83%BC%E5%B7%9E))):

```
カムデンは（39.937195, -75.106186）に位置する。
```

This small PR fixes the problem by ensuring `str` type for the `piece`.
Please let me know if you notice anything.

Sincerely,