### PR TITLE
tokenization: log spm usage only in debug mode to avoid console spamming

### DIFF
--- a/tokenization.py
+++ b/tokenization.py
@@ -233,7 +233,7 @@ class FullTokenizer(object):
 
   def convert_tokens_to_ids(self, tokens):
     if self.sp_model:
-      tf.logging.info("using sentence piece tokenzier.")
+      tf.logging.debug("using sentence piece tokenizer.")
       return [self.sp_model.PieceToId(
           printable_text(token)) for token in tokens]
     else:
@@ -241,7 +241,7 @@ class FullTokenizer(object):
 
   def convert_ids_to_tokens(self, ids):
     if self.sp_model:
-      tf.logging.info("using sentence piece tokenzier.")
+      tf.logging.debug("using sentence piece tokenizer.")
       return [self.sp_model.IdToPiece(id_) for id_ in ids]
     else:
       return convert_by_vocab(self.inv_vocab, ids)


### PR DESCRIPTION
Hi,

I'm not sure if the repo is currently maintained, but this PR decreases the log level (from info to debug) for the SPM tokenization usage message. It will be displayed whenever a line is tokenized/detokenized which is very annoying, because the default log level is info.